### PR TITLE
feat: cache by range max bound

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -68,6 +68,25 @@ function* _install(parentDir, pkg, options) {
     return dir;
   }
 
+  // cache if tow ranges have the same max bound
+  let rangeKey;
+  if (p.type === 'range') {
+    const max = utils.getMaxRange(p.spec);
+    if (max) {
+      rangeKey = `install:${pkg.name}:range:${max}`;
+      const c = options.cache[rangeKey];
+      if (c) {
+        const pkg = c.package;
+        if (semver.satisfies(pkg.version, p.spec)) {
+          const dir = c.dir;
+          yield bin(parentDir, pkg, dir);
+          yield link(parentDir, pkg, dir);
+          return dir;
+        }
+      }
+    }
+  }
+
   // get npm package info
   const pkgUrl = getPackageNpmUri(pkg, options);
   const result = yield get(pkgUrl, {
@@ -88,6 +107,13 @@ function* _install(parentDir, pkg, options) {
     package: realPkg,
     dir: realPkgDir,
   };
+
+  if (rangeKey) {
+    options.cache[rangeKey] = {
+      package: realPkg,
+      dir: realPkgDir,
+    };
+  }
 
   const existsVersion = options.latestVersions.get(realPkg.name);
   if (existsVersion) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,3 +107,11 @@ exports.runScript = function runScript(pkgDir, script, options) {
     stdio: 'inherit',
   });
 };
+
+exports.getMaxRange = function(spec) {
+  // >=1.0.0 <2.0.0
+  const r = /^>=.*?<(.*?)$/.exec(spec);
+  if (r) {
+    return r[1];
+  }
+};

--- a/test/sameMaxRange.test.js
+++ b/test/sameMaxRange.test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright(c) cnpm and other contributors.
+ * MIT Licensed
+ *
+ * Authors:
+ *   dead_horse <dead_horse@qq.com>
+ */
+
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const assert = require('assert');
+const path = require('path');
+const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
+const npminstall = require('../');
+
+describe('test/sameMaxRange.test.js', function() {
+  const tmp = path.join(__dirname, 'fixtures', 'tmp');
+
+  function cleanup() {
+    rimraf.sync(tmp);
+  }
+
+  beforeEach(function() {
+    cleanup();
+    mkdirp.sync(tmp);
+  });
+  afterEach(cleanup);
+
+
+  it('should install same max range ok', function*() {
+    const options = {
+      root: tmp,
+      cacheDir: null,
+      pkgs: [
+        {name: 'debug', version: '~2.1.0'},
+        {name: 'debug', version: '~2.1.1'},
+      ],
+    };
+    yield npminstall(options);
+    assert(options.cache['install:debug:range:2.2.0'].package.version);
+  });
+});


### PR DESCRIPTION
chair 这种规模可以少100多次对 npm registry 的请求