### PR TITLE
fix: --foo=bar should use `npm_config_` env prefix name

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -71,7 +71,7 @@ const env = {
 for (const key in argv) {
   const value = argv[key];
   if (value && typeof value === 'string') {
-    env['npm_' + key] = value;
+    env['npm_config_' + key] = value;
   }
 }
 

--- a/test/fixtures/auto-set-npm-env/postinstall.js
+++ b/test/fixtures/auto-set-npm-env/postinstall.js
@@ -1,1 +1,1 @@
-console.log('npm_foo_bar_haha = %s', process.env.npm_foo_bar_haha);
+console.log('npm_config_foo_bar_haha = %s', process.env.npm_config_foo_bar_haha);

--- a/test/postinstall.test.js
+++ b/test/postinstall.test.js
@@ -87,7 +87,7 @@ describe('test/postinstall.test.js', () => {
         })
         .debug()
         .expect('stdout', /\[pedding@1\.0\.0] installed/)
-        .expect('stdout', /npm_foo_bar_haha = okok/)
+        .expect('stdout', /npm_config_foo_bar_haha = okok/)
         .expect('code', 0)
         .end(err => {
           assert(!err, err && err.message);


### PR DESCRIPTION
`--foo=bar` => `npm_config_foo: bar`