### PR TITLE
feat: add referer for registry access log

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -36,6 +36,7 @@ function* get(url, options, globalOptions) {
   options.agent = httpKeepaliveAgent;
   options.headers = options.headers || {};
   options.headers['User-Agent'] = USER_AGENT;
+  options.headers.Referer = globalOptions.referer;
   if (globalOptions) {
     options.rejectUnauthorized = globalOptions.strictSSL;
   }

--- a/lib/local_install.js
+++ b/lib/local_install.js
@@ -26,6 +26,7 @@ const bytes = require('bytes');
 const Module = require('module');
 const fs = require('mz/fs');
 const os = require('os');
+const uuid = require('uuid');
 const utils = require('./utils');
 const postinstall = require('./postinstall');
 const preinstall = require('./preinstall');
@@ -107,6 +108,14 @@ module.exports = function*(options) {
       ? dependencies(rootPkg).prod
       : dependencies(rootPkg).all;
   }
+  options.referer = 'install';
+  if (pkgs.length > 0) {
+    options.referer += ' ' + pkgs.map(pkg => pkg.name).join(' ');
+  }
+  if (options.production) {
+    options.referer += ' --production';
+  }
+  options.referer += ' --uuid=' + uuid.v1();
 
   if (installRoot) yield preinstall(rootPkg, options.root, options);
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "await-event": "~1.0.0",
+    "binary-mirror-config": "^1.0.1",
     "bytes": "~2.2.0",
     "chalk": "~1.1.1",
     "cmd-shim": "~2.0.1",
@@ -29,6 +30,7 @@
     "co-parallel": "~1.0.0",
     "debug": "~2.2.0",
     "destroy": "~1.0.4",
+    "minimist": "~1.2.0",
     "mkdirp": "~0.5.1",
     "ms": "~0.7.1",
     "mz": "~2.3.0",
@@ -41,8 +43,7 @@
     "tar": "~2.2.1",
     "urllib": "~2.7.1",
     "utility": "~1.6.0",
-    "minimist": "~1.2.0",
-    "binary-mirror-config": "^1.0.1"
+    "uuid": "~2.0.1"
   },
   "devDependencies": {
     "autod": "*",


### PR DESCRIPTION
\- - 121.0.29.221 [01/Apr/2016:14:53:48 +0800] "GET /ms/download/ms-0.7.1.tgz HTTP/1.1" 302 5 "install koa should --production --uuid=7d5ac1b0-f7d6-11e5-b5fa-172edeb64a6a" "npminstall/1.5.3 node-urllib/2.7.3 Node.js/4.4.1 (OS X El Capitan; x64)" 0.007 0.007

121.0.29.221 - 100.97.90.133 [01/Apr/2016:14:53:27 +0800] "GET /lodash.keys/%3E%3D3.1.2%20%3C4.0.0 HTTP/1.0" 200 2376 "install less-loader antd react react-dom mocha grunt-mocha-test --uuid=6f138380-f7d6-11e5-b5fa-172edeb64a6a" "npminstall/1.5.3 node-urllib/2.7.3 Node.js/4.4.1 (OS X El Capitan; x64)" 0.030 0.029


closes #66