### PR TITLE
fix: utils.forceSymlink precheck dest dir exists

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,6 +81,13 @@ exports.forceSymlink = function* forceSymlink(src, dest, type) {
     // ignore error, will always cleanup dest
   }
   yield exports.rimraf(dest);
+
+  const destDir = path.dirname(dest);
+  // check if destDir is not exist
+  if (!(yield fs.exists(destDir))) {
+    yield exports.mkdirp(destDir);
+  }
+
   yield fs.symlink(relative, dest, type);
   return relative;
 };

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -38,4 +38,16 @@ describe('test/bin.test.js', () => {
     assert.equal(pkg.version, '1.6.0');
     assert(fs.existsSync(path.join(root, 'node_modules', '.bin', 'yo')));
   });
+
+  it('should create bin folders for scoped pkg', function*() {
+    yield npminstall({
+      root: root,
+      pkgs: [
+        { name: '@bigfunger/decompress-zip' },
+      ],
+    });
+    const pkg = yield readJSON(path.join(root, 'node_modules', '@bigfunger/decompress-zip', 'package.json'));
+    assert.equal(pkg.name, '@bigfunger/decompress-zip');
+    assert(fs.existsSync(path.join(root, 'node_modules', '.bin/@bigfunger', 'decompress-zip')));
+  });
 });


### PR DESCRIPTION
- issue reference of https://github.com/cnpm/cnpm/issues/112

test:
```javascript
mocha -r thunk-mocha -t 120000 test/bin.test.js   # passed 
```

