### PR TITLE
feat: support global install prefix argv

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -32,6 +32,7 @@ const argv = parseArgs(process.argv.slice(2), {
   string: [
     'root',
     'registry',
+    'prefix',
   ],
   boolean: [
     'version',
@@ -160,7 +161,8 @@ co(function*() {
   config.ignoreScripts = argv['ignore-scripts'] || getIgnoreScripts();
   // -g install to npm's global prefix
   if (argv.global) {
-    const npmPrefix = getPrefix();
+    // support custom prefix for global install
+    const npmPrefix = argv.prefix || getPrefix();
     if (process.platform === 'win32') {
       config.targetDir = npmPrefix;
       config.binDir = npmPrefix;

--- a/test/installGlobal.test.js
+++ b/test/installGlobal.test.js
@@ -16,6 +16,7 @@ const assert = require('assert');
 const fs = require('mz/fs');
 const path = require('path');
 const rimraf = require('rimraf');
+const coffee = require('coffee');
 const installGlobal = require('./npminstall').installGlobal;
 const mkdirp = require('../lib/utils').mkdirp;
 
@@ -75,5 +76,17 @@ describe('test/installGlobal.test.js', function() {
 
     assert(yield fs.exists(path.join(tmp, 'bin', 'contributors')));
     assert(yield fs.exists(path.join(tmp, 'lib', 'node_modules', 'contributors')));
+  });
+
+  it('should install with global prefix', done => {
+    coffee.fork(require.resolve('../bin/install.js'), [
+      `--prefix=${tmp}`,
+      '-g',
+      'pedding',
+    ])
+    .debug()
+    .expect(/All packages installed/)
+    .expect('code', 0)
+    .end(done);
   });
 });


### PR DESCRIPTION
```bash
npminstall -g foo --prefix=/tmp/path
```