### PR TITLE
fix: global prefix support `~/foo/path`

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -11,6 +11,7 @@ const util = require('util');
 const execSync = require('child_process').execSync;
 const fs = require('mz/fs');
 const parseArgs = require('minimist');
+const homedir = require('node-homedir');
 const utils = require('../lib/utils');
 const globalConfig = require('../lib/config');
 const installLocal = require('..').installLocal;
@@ -206,7 +207,11 @@ co(function* () {
   // -g install to npm's global prefix
   if (argv.global) {
     // support custom prefix for global install
-    const npmPrefix = argv.prefix || getPrefix();
+    let npmPrefix = argv.prefix || getPrefix();
+    if (npmPrefix[0] === '~') {
+      // convert '~/foo/path' => '$HOME/foo/path'
+      npmPrefix = homedir() + npmPrefix.substring(1);
+    }
     if (process.platform === 'win32') {
       config.targetDir = npmPrefix;
       config.binDir = npmPrefix;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "ms": "^0.7.1",
     "mz": "^2.4.0",
     "node-gyp": "^3.3.1",
+    "node-homedir": "^0.0.1",
     "node-uuid": "^1.4.7",
     "normalize-git-url": "^3.0.2",
     "npm-package-arg": "^4.2.0",


### PR DESCRIPTION
closes https://github.com/cnpm/npminstall/issues/145