### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/download/git.js
+++ b/lib/download/git.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const urlutil = require('url');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const chalk = require('chalk');
 const runscript = require('runscript');
 const ngu = require('normalize-git-url');

--- a/lib/download/local.js
+++ b/lib/download/local.js
@@ -4,7 +4,7 @@ const debug = require('debug')('npminstall:download:local');
 const fs = require('mz/fs');
 const path = require('path');
 const chalk = require('chalk');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const utils = require('../utils');
 
 module.exports = function* (pkg, options) {

--- a/lib/download/remote.js
+++ b/lib/download/remote.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const chalk = require('chalk');
 const utils = require('../utils');
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "mz": "^2.4.0",
     "node-gyp": "^3.4.0",
     "node-homedir": "^0.0.1",
-    "node-uuid": "^1.4.7",
     "normalize-git-url": "^3.0.2",
     "npm-package-arg": "^4.2.0",
     "ora": "^0.3.0",
@@ -52,7 +51,7 @@
     "tar": "^2.2.1",
     "urllib": "^2.17.0",
     "utility": "^1.8.0",
-    "uuid": "^2.0.3"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "autod": "2",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.