### PR TITLE
fix: get max satisfy version from root dependencies instead of *

### DIFF
--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -39,6 +39,10 @@ module.exports = function dependencies(pkg) {
       return results;
     },
 
+    get prodMap() {
+      return prod;
+    },
+
     get prod() {
       const results = [];
       for (const name in prod) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -39,6 +39,15 @@ function* _install(parentDir, pkg, ancestors, options) {
     pkg.version = '*';
   }
 
+  if (pkg.version === '*') {
+    // try to get max satisfy version from options.rootPkgDependencies
+    const map = options.production ? options.rootPkgDependencies.prodMap : options.rootPkgDependencies.allMap;
+    if (map[pkg.name]) {
+      pkg.version = map[pkg.name];
+      debug('use root dependencies version(%s@%s) instead of *', pkg.name, pkg.version);
+    }
+  }
+
   debug('[%s/%s] install %s@%s in %s',
     options.progresses.finishedInstallTasks,
     options.progresses.installTasks,

--- a/lib/local_install.js
+++ b/lib/local_install.js
@@ -62,6 +62,7 @@ function* _install(options) {
   const displayName = `${rootPkg.name}@${rootPkg.version}`;
   let pkgs = options.pkgs;
   const rootPkgDependencies = dependencies(rootPkg);
+  options.rootPkgDependencies = rootPkgDependencies;
   if (pkgs.length === 0) {
     pkgs = options.production ? rootPkgDependencies.prod : rootPkgDependencies.all;
     debug(`about to locally install pkgs (production: ${options.production}): ${JSON.stringify(pkgs, null, 2)}`);

--- a/test/fixtures/try-to-use-one-version/package.json
+++ b/test/fixtures/try-to-use-one-version/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "try-to-use-one-version",
+  "devDependencies": {
+    "@types/react": "15.0.4",
+    "@types/react-dom": "0.14.18"
+  }
+}

--- a/test/use-exists-version.test.js
+++ b/test/use-exists-version.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const coffee = require('coffee');
+const rimraf = require('rimraf');
+const path = require('path');
+const assert = require('assert');
+
+describe('use-exists-version.test.js', () => {
+  const tmp = path.join(__dirname, 'fixtures', 'try-to-use-one-version');
+  const bin = path.join(__dirname, '../bin/install.js');
+
+  function cleanup() {
+    rimraf.sync(path.join(tmp, 'node_modules'));
+  }
+
+  beforeEach(cleanup);
+
+  it('should replace tarball url to other', function* () {
+    yield coffee.fork(bin, [ '-d' ], { cwd: tmp })
+      .debug()
+      .expect('code', 0)
+      .expect('stdout', /All packages installed/)
+      .end();
+    const pkg = require(path.join(tmp, 'node_modules/@types/react-dom/node_modules/@types/react/package.json'));
+    assert(pkg.version === '15.0.4');
+  });
+});


### PR DESCRIPTION
closes https://github.com/cnpm/npminstall/issues/192