### PR TITLE
feat: lookup ancestor's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Options:
   --ignore-scripts: ignore all preinstall / install and postinstall scripts during the installation
   --forbidden-licenses: forbit install packages which used these licenses
   --engine-strict: refuse to install (or even consider installing) any package that claims to not be compatible with the current Node.js version.
+  --flatten: flatten dependencies by matching ancestors' dependencies
 ```
 
 #### npmuninstall

--- a/bin/install.js
+++ b/bin/install.js
@@ -42,6 +42,7 @@ const argv = parseArgs(orignalArgv, {
     'detail',
     'trace',
     'engine-strict',
+    'flatten',
   ],
   alias: {
     // npm install [-S|--save|-D|--save-dev|-O|--save-optional] [-E|--save-exact] [-d|--detail]
@@ -94,6 +95,7 @@ Options:
   --ignore-scripts: ignore all preinstall / install and postinstall scripts during the installation
   --forbidden-licenses: forbit install packages which used these licenses
   --engine-strict: refuse to install (or even consider installing) any package that claims to not be compatible with the current Node.js version.
+  --flatten: flatten dependencies by matching ancestors' dependencies
 `
   );
   process.exit(0);
@@ -124,6 +126,8 @@ if (production) {
 
 let forbiddenLicenses = argv['forbidden-licenses'];
 forbiddenLicenses = forbiddenLicenses ? forbiddenLicenses.split(',') : null;
+
+const flatten = argv.flatten;
 
 // if in china, will automatic using chines registry and mirros.
 const inChina = argv.china || !!process.env.npm_china;
@@ -195,6 +199,7 @@ co(function* () {
     env,
     binaryMirrors,
     forbiddenLicenses,
+    flatten,
   };
   config.strictSSL = getStrictSSL();
   config.ignoreScripts = argv['ignore-scripts'] || getIgnoreScripts();

--- a/lib/download/npm.js
+++ b/lib/download/npm.js
@@ -21,6 +21,22 @@ const utils = require('../utils');
 const RANGE_RE = /^>=/;
 
 module.exports = function* (pkg, options) {
+  const realPkg = yield resolve(pkg, options);
+  // download tarball and unzip
+  const info = yield download(realPkg, options);
+  info.package = realPkg;
+  return info;
+};
+
+module.exports.resolve = resolve;
+
+function* resolve(pkg, options) {
+  // check cache first
+  const cacheKey = `npm:resolve:${pkg.raw}`;
+  if (options.cache[cacheKey]) {
+    debug('resolve hit cache: %s', cacheKey);
+    return options.cache[cacheKey];
+  }
   // get npm package info
   const pkgUrl = getPackageNpmUri(pkg, options);
   let result;
@@ -88,11 +104,11 @@ module.exports = function* (pkg, options) {
 
   debug('[%s@%s] spec: %s, real version: %s', pkg.name, pkg.version, pkg.spec, realPkg.version);
 
-  // download tarball and unzip
-  const info = yield download(realPkg, options);
-  info.package = realPkg;
-  return info;
-};
+  // cache resolve result
+  options.cache[cacheKey] = realPkg;
+
+  return realPkg;
+}
 
 function getPackageNpmUri(pkg, options) {
   let name = pkg.name;

--- a/lib/install.js
+++ b/lib/install.js
@@ -14,6 +14,7 @@ const preinstall = require('./preinstall');
 const bin = require('./bin');
 const link = require('./link');
 const dependencies = require('./dependencies');
+const resolve = require('./download/npm').resolve;
 
 module.exports = install;
 
@@ -39,15 +40,6 @@ function* _install(parentDir, pkg, ancestors, options) {
     pkg.version = '*';
   }
 
-  if (pkg.version === '*') {
-    // try to get max satisfy version from options.rootPkgDependencies
-    const map = options.production ? options.rootPkgDependencies.prodMap : options.rootPkgDependencies.allMap;
-    if (map[pkg.name]) {
-      pkg.version = map[pkg.name];
-      debug('use root dependencies version(%s@%s) instead of *', pkg.name, pkg.version);
-    }
-  }
-
   debug('[%s/%s] install %s@%s in %s',
     options.progresses.finishedInstallTasks,
     options.progresses.installTasks,
@@ -55,7 +47,16 @@ function* _install(parentDir, pkg, ancestors, options) {
   if (options.spinner) {
     options.spinner.text = `[${options.progresses.finishedInstallTasks}/${options.progresses.installTasks}] Installing ${pkg.name}@${pkg.version}`;
   }
-  const p = npa(pkg.name ? `${pkg.name}@${pkg.version}` : pkg.version);
+  let p = npa(pkg.name ? `${pkg.name}@${pkg.version}` : pkg.version);
+  const displayName = p.displayName = getDisplayName(pkg, ancestors);
+
+  if (options.flatten) {
+    const satisfied = yield matchAncestorDependencies(p, ancestors, options);
+    if (satisfied) {
+      p = satisfied;
+      pkg.version = satisfied.rawSpec;
+    }
+  }
 
   const key = `install:${pkg.name}@${pkg.version}`;
   const c = options.cache[key]; // {package: packageInfo, dir: realDir}
@@ -92,7 +93,6 @@ function* _install(parentDir, pkg, ancestors, options) {
     }
   }
 
-  p.displayName = getDisplayName(pkg, ancestors);
   const info = yield download(p, options);
   const realPkg = info.package;
   const realPkgDir = info.dir;
@@ -137,8 +137,6 @@ function* _install(parentDir, pkg, ancestors, options) {
   // 4. link bin files
   // 5. link package to node_modules dir
 
-  let grandfatherPkg;
-  const displayName = getDisplayName(realPkg, ancestors);
   try {
     if (realPkg.publish_time && realPkg.publish_time >= options.recentlyUpdateMinDateTime) {
       options.recentlyUpdates.set(`${displayName}`, new Date(realPkg.publish_time));
@@ -200,7 +198,9 @@ function* _install(parentDir, pkg, ancestors, options) {
     const bundledDependencies = yield getBundleDependencies(realPkg, realPkgDir);
     yield bundledDependencies.map(name => bundleBin(name, realPkgDir, options));
 
-    const pkgs = dependencies(realPkg).prod;
+    const deps = dependencies(realPkg);
+    const pkgs = deps.prod;
+
     if (pkgs.length > 0) {
       const nodeModulesDir = path.join(realPkgDir, 'node_modules');
       yield utils.mkdirp(nodeModulesDir);
@@ -209,27 +209,12 @@ function* _install(parentDir, pkg, ancestors, options) {
         if (bundledDependencies.indexOf(childPkg.name) !== -1) {
           continue;
         }
-        // if version format "n.x", check grandfather's dependencies
-        if (/^\d+\.x$/.test(childPkg.version)) {
-          if (!grandfatherPkg) {
-            grandfatherPkg = yield utils.readJSON(path.join(parentDir, 'package.json'));
-          }
-          const version = grandfatherPkg.dependencies && grandfatherPkg.dependencies[childPkg.name];
-          if (version && /^[~^]\d+\.\d+\.\d+$/.test(version)) {
-            if (semver.satisfies(version.substring(1), childPkg.version)) {
-              options.console.info(
-                '%s %s use %s\'s dependencies version: %j instead of %j',
-                chalk.yellow('anti semver'),
-                chalk.gray(getDisplayName(childPkg, ancestors.concat(realPkg.name))),
-                grandfatherPkg.name,
-                version,
-                childPkg.version
-              );
-              childPkg.version = version;
-            }
-          }
-        }
-        tasks.push(install(realPkgDir, childPkg, ancestors.concat(`${realPkg.name}@${realPkg.version}`), options));
+
+        tasks.push(install(realPkgDir, childPkg, ancestors.concat({
+          displayName: `${realPkg.name}@${realPkg.version}`,
+          name: realPkg.name,
+          dependencies: deps.prodMap,
+        }), options));
       }
       yield parallel(tasks, 10);
     }
@@ -289,5 +274,52 @@ function* bundleBin(name, parentDir, options) {
 }
 
 function getDisplayName(pkg, ancestors) {
-  return ancestors.concat([ `${pkg.name}@${pkg.version}` ]).join(chalk.gray(' › '));
+  return ancestors
+    .map(ancestor => ancestor.displayName || ancestor)
+    .concat([ `${pkg.name}@${pkg.version}` ])
+    .join(chalk.gray(' › '));
+}
+
+function* matchAncestorDependencies(childPkg, ancestors, options) {
+  // only need check npm types
+  if (!fromNpm(childPkg.type)) return;
+  const rootPkgDependencies = options.production ? options.rootPkgDependencies.prodMap : options.rootPkgDependencies.allMap;
+
+  ancestors = [{ dependencies: rootPkgDependencies, name: 'root package.json' }].concat(ancestors);
+  for (const ancestor of ancestors) {
+    const ancestorVersion = ancestor.dependencies[childPkg.name];
+    if (!ancestorVersion) continue;
+    const ancestorPkg = npa(`${childPkg.name}@${ancestorVersion}`);
+    if (!fromNpm(ancestorPkg.type)) continue;
+    ancestorPkg.parent = ancestor.name;
+    const satisfied = yield satisfiesRange(childPkg, ancestorPkg, options);
+    if (satisfied) return satisfied;
+  }
+}
+
+function* satisfiesRange(childPkg, ancestorPkg, options) {
+  if (childPkg.raw === ancestorPkg.raw) return;
+
+  const resolveAncestorPkg = yield resolve(ancestorPkg, options);
+  if (semver.satisfies(resolveAncestorPkg.version, childPkg.spec)) {
+    const resolveChildPkg = yield resolve(childPkg, options);
+    if (resolveChildPkg.version !== resolveAncestorPkg.version) {
+      options.paddingMessages.push([
+        'warn',
+        '%s %s delcares %s(resolved as %s) but using ancestor(%s)\'s dependency %s(resolved as %s)',
+        chalk.magenta('anti semver'),
+        chalk.gray(childPkg.displayName),
+        chalk.yellow(childPkg.rawSpec),
+        chalk.yellow(resolveChildPkg.version),
+        chalk.gray(ancestorPkg.parent),
+        chalk.yellow(ancestorPkg.rawSpec),
+        chalk.yellow(resolveAncestorPkg.version),
+      ]);
+      return ancestorPkg;
+    }
+  }
+}
+
+function fromNpm(type) {
+  return [ 'remote', 'local', 'hosted', 'git' ].indexOf(type) === -1;
 }

--- a/lib/install.js
+++ b/lib/install.js
@@ -146,7 +146,7 @@ function* _install(parentDir, pkg, ancestors, options) {
       options.paddingMessages.push([
         'warn',
         '%s %s %s',
-        chalk.magenta('deprecate'),
+        chalk.red('deprecate'),
         chalk.gray(displayName),
         realPkg.deprecated,
       ]);

--- a/lib/local_install.js
+++ b/lib/local_install.js
@@ -42,6 +42,7 @@ const formatInstallOptions = require('./format_install_options');
  *  - {Boolean} [ignoreScripts] - ignore pre / post install scripts, default is `false`
  *  - {Array} [forbiddenLicenses] - forbit install packages which used these licenses
  *  - {Boolean} [trace] - show memory and cpu usages traces of installation
+ *  - {Boolean} [flatten] - flatten dependencies by matching ancestors' dependencies
  */
 module.exports = function* (options) {
   options = formatInstallOptions(options);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "test": "mocha -r thunk-mocha -r intelli-espower-loader -t 200000 test/*.test.js",
-    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- -r thunk-mocha -r intelli-espower-loader -t 200000 test/*.test.js",
+    "test-cov": "istanbul cover --report none --print none node_modules/mocha/bin/_mocha -- -r thunk-mocha -r intelli-espower-loader -t 200000 test/*.test.js && istanbul report text-summary json lcov",
     "test-local": "npm_china=true local=true mocha -r thunk-mocha -r intelli-espower-loader -t 200000 test/*.test.js",
     "lint": "eslint . --fix",
     "ci": "npm run lint && npm run test-cov",

--- a/test/fixtures/flatten/mod1/package.json
+++ b/test/fixtures/flatten/mod1/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mod1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "koa": "1.1.0",
+    "mod2": "./mod2",
+    "mod3": "./mod3",
+    "mod4": "./mod4"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/flatten/mod2/package.json
+++ b/test/fixtures/flatten/mod2/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mod2",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "koa": "~1.1.0",
+    "mod3": "./mod3",
+    "mod4": "./mod4"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/flatten/mod3/package.json
+++ b/test/fixtures/flatten/mod3/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mod3",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "koa": "^1.1.0",
+    "mod4": "./mod4"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/fixtures/flatten/mod4/package.json
+++ b/test/fixtures/flatten/mod4/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mod4",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "koa": "0.10.0"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/flatten.test.js
+++ b/test/flatten.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const coffee = require('coffee');
+const rimraf = require('rimraf');
+const path = require('path');
+const assert = require('assert');
+const fs = require('fs');
+
+describe('use-exists-version.test.js', () => {
+  const tmp = path.join(__dirname, 'fixtures', 'flatten');
+  const bin = path.join(__dirname, '../bin/install.js');
+
+  function getPkg(subPath) {
+    return JSON.parse(fs.readFileSync(path.join(tmp, subPath)));
+  }
+
+  function cleanup() {
+    rimraf.sync(path.join(tmp, 'node_modules'));
+  }
+
+  beforeEach(cleanup);
+
+  it('should force all koa to 1.1.0', function* () {
+    yield coffee.fork(bin, [ '-d', '--flatten', './mod1' ], { cwd: tmp })
+      .debug()
+      .expect('code', 0)
+      .expect('stdout', /All packages installed/)
+      .end();
+    assert(getPkg('node_modules/mod1/node_modules/koa/package.json').version === '1.1.0');
+    assert(getPkg('node_modules/mod1/node_modules/mod2/node_modules/koa/package.json').version === '1.1.0');
+    assert(getPkg('node_modules/mod1/node_modules/mod3/node_modules/koa/package.json').version === '1.1.0');
+    assert(getPkg('node_modules/mod1/node_modules/mod4/node_modules/koa/package.json').version === '0.10.0');
+  });
+
+  it('should force all koa to ~1.1.2', function* () {
+    yield coffee.fork(bin, [ '-d', '--flatten', './mod2' ], { cwd: tmp })
+      .debug()
+      .expect('code', 0)
+      .expect('stdout', /All packages installed/)
+      .end();
+    assert(getPkg('node_modules/mod2/node_modules/koa/package.json').version === '1.1.2');
+    assert(getPkg('node_modules/mod2/node_modules/mod3/node_modules/koa/package.json').version === '1.1.2');
+    assert(getPkg('node_modules/mod2/node_modules/mod4/node_modules/koa/package.json').version === '0.10.0');
+  });
+
+  it('should not force koa version without flatten', function* () {
+    yield coffee.fork(bin, [ '-d', './mod1' ], { cwd: tmp })
+      .debug()
+      .expect('code', 0)
+      .expect('stdout', /All packages installed/)
+      .end();
+    assert(getPkg('node_modules/mod1/node_modules/koa/package.json').version === '1.1.0');
+    assert(getPkg('node_modules/mod1/node_modules/mod2/node_modules/koa/package.json').version === '1.1.2');
+    assert(getPkg('node_modules/mod1/node_modules/mod3/node_modules/koa/package.json').version !== '1.1.0');
+    assert(getPkg('node_modules/mod1/node_modules/mod4/node_modules/koa/package.json').version === '0.10.0');
+  });
+});

--- a/test/use-exists-version.test.js
+++ b/test/use-exists-version.test.js
@@ -16,7 +16,7 @@ describe('use-exists-version.test.js', () => {
   beforeEach(cleanup);
 
   it('should replace tarball url to other', function* () {
-    yield coffee.fork(bin, [ '-d' ], { cwd: tmp })
+    yield coffee.fork(bin, [ '-d', '--flatten' ], { cwd: tmp })
       .debug()
       .expect('code', 0)
       .expect('stdout', /All packages installed/)


### PR DESCRIPTION
两种不同的选择：

1. 完全遵循 semver 原则，各个模块独立安装自身依赖。（有利于 node 运行环境，不需要考虑体积问题）
2. 在遵循 semver 的原则下，尽可能合并模块版本。（有利于前端）

> the ~ prefix says "match any patch version greater than or equal to the one I specified"

按照上面 [npm 的人对 semver 的解释](https://github.com/npm/npm/issues/11887#issuecomment-201615642)，`~1.1.0` 并不保证一定安装到符合这个规则的最新版本。但是一定是使用到符合这条规则的版本。

npm 的安装策略如下：

```sh
root/
  koa@1.1.0
  mod/
    koa@~1.1.0

root/
  koa@1.1.0
  mod/
    koa@^1.1.0
# 上面两个依赖树安装到的 koa 版本都是 1.1.0

root/
  koa@~1.1.0
  mod/
    koa@^1.1.0
# 上面依赖树安装到的 koa 版本都是 ~1.1.2

root/
  mod/
    koa@^1.1.0
  moe/
    koa@~1.1.0
# 上面依赖树会安装两个不同版本的 koa
```



在一些项目上测试了一下，egg 和 antd 都没有遇到这个问题，一般就是 babel 那些可能遇到，但是影响不到，所以需要加 `--flatten` 的 flag 来开启 2，默认都是走 1 的方式，之前的 hack 都去掉了。

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/npminstall/197)
<!-- Reviewable:end -->
