### PR TITLE
support customize cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Options:
   --flatten: flatten dependencies by matching ancestors dependencies
   --registry-only: make sure all packages install from registry. Any package is installed from remote(e.g.: git, remote url) cause install fail.
   --cache-strict: use disk cache even on production env
+  --cache: use the specified directory as the disk cache directory
 ```
 
 #### npmuninstall

--- a/bin/install.js
+++ b/bin/install.js
@@ -104,7 +104,7 @@ Options:
   --flatten: flatten dependencies by matching ancestors' dependencies
   --registry-only: make sure all packages install from registry. Any package is installed from remote(e.g.: git, remote url) cause install fail.
   --cache-strict: use disk cache even on production env.
-  --cache: use the specified directory as disk cache directory
+  --cache: use the specified directory as the disk cache directory
 `
   );
   process.exit(0);

--- a/bin/install.js
+++ b/bin/install.js
@@ -209,7 +209,7 @@ co(function* () {
     if (!utils.isDirectory(cacheDir)) {
       yield fse.ensureDir(cacheDir);
     }
-    if (!utils.readAndWritableDirecotry(cacheDir)) {
+    if (!(yield utils.readAndWritableDirecotry(cacheDir))) {
       throw new Error(`cacheDir: ${cacheDir} should have read/write permissions`);
     }
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,6 +107,36 @@ exports.forceStat = function* isSymbolicLink(linkPath) {
   return stat;
 };
 
+exports.isDirectory = function* isDirectory(filepath) {
+  const exists = yield fs.exists(filepath);
+  if (exists) {
+    const stat = yield exports.forceStat(filepath);
+    return stat.isDirectory();
+  }
+  return exists;
+}
+
+exports.readAndWritableDirecotry = function* readAndWritableDirecotry(filepath) {
+  let result;
+  try {
+    yield fs.access(filepath, fs.constants.W_OK | fs.constants.R_OK);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+exports.realPath = function realPath(filepath) {
+  const pwd = process.cwd();
+  if (filepath.indexOf('~') === 0) {
+    filepath = filepath.replace('~', process.env.HOME);
+  }
+  if (filepath.indexOf('/') === 0) {
+    return path.resolve(filepath);
+  }
+  return path.resolve(pwd, filepath);
+}
+
 function setNpmPackageEnv(env, key, value) {
   const t = typeof value;
   if (t === 'string' || t === 'number' || t === 'boolean') {

--- a/test/install-cache-strict.test.js
+++ b/test/install-cache-strict.test.js
@@ -16,6 +16,7 @@ describe('test/install-cache-strict.test.js', () => {
 
   function cleanup() {
     rimraf.sync(path.join(demo, 'node_modules'));
+    rimraf.sync(path.join(demo, '.npm_cache'))
     rimraf.sync(homedir);
   }
 
@@ -49,4 +50,79 @@ describe('test/install-cache-strict.test.js', () => {
     .end();
     assert(fs.statSync(path.join(homedir, '.npminstall_tarball/d/e/b/u/debug')));
   });
+
+  it('should read disk cache from custimize direcotry on --cache=~/.npm_cache', function* () {
+    yield coffee.fork(npminstall, [ '--cache=~/.npm_cache' ], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir,
+      }),
+    })
+    .debug()
+    .end();
+    assert(fs.statSync(path.join(homedir, '.npm_cache/d/e/b/u/debug')));
+  });
+
+  it('should read disk cache from customize direcotry on --cache=~/.npm_cache', function* () {
+    yield coffee.fork(npminstall, [ '--cache=~/.npm_cache' ], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir,
+      }),
+    })
+    .debug()
+    .end();
+    assert(fs.statSync(path.join(homedir, '.npm_cache/d/e/b/u/debug')));
+  });
+
+  it('should read disk cache from customize directory on --cache=.npm_cache', function* () {
+    yield coffee.fork(npminstall, [ '--cache=.npm_cache' ], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir
+      }),
+    })
+    .debug()
+    .end();
+    assert(fs.statSync(path.join(demo, '.npm_cache/d/e/b/u/debug')));
+  });
+
+  it('should read disk cache from customize directory on absolute path', function* () {
+    const absolutePath = path.join(homedir, '.npm_cache');
+    yield coffee.fork(npminstall, [ `--cache=${absolutePath}` ], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir
+      }),
+    })
+    .debug()
+    .end();
+    assert(fs.statSync(path.join(absolutePath, 'd/e/b/u/debug')));
+  });
+
+  it('should read disk cache from customize directroy on --cache=../.tmp/.npm_cache', function* () {
+    yield coffee.fork(npminstall, [ `--cache=../.tmp/.npm_cache` ], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir
+      }),
+    })
+    .debug()
+    .end();
+
+    assert(fs.statSync(path.join(homedir, '.npm_cache/d/e/b/u/debug')));
+  });
+
+  it('should read disk cache from customize directory on --cache-strict --production --cache=~/.npm_cache', function* () {
+    yield coffee.fork(npminstall, [ '--cache=~/.npm_cache', '--production', '--cache-strict' ], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir,
+      }),
+    })
+    .debug()
+    .end();
+    assert(fs.statSync(path.join(homedir, '.npm_cache/d/e/b/u/debug')));
+  });
+
 });


### PR DESCRIPTION
Npminstall does not support customize cache directory. This PR make npminstall allow user to customize cache directory.

Example:

- support home alias
```
$ npminstall --cache=~/.npm_cache
```

- relative path of cwd

```
$ npminstall --cache=../.npm_cache
```

- absolute path 

```
$ npminstall --cache=/home/foo/.npm_cache
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cnpm/npminstall/255)
<!-- Reviewable:end -->
