### PR TITLE
fix: don't prune assets dir

### DIFF
--- a/lib/download/npm.js
+++ b/lib/download/npm.js
@@ -492,7 +492,6 @@ const defaultDirectories = toMap([
   '.vscode',
   'website',
   'images',
-  'assets',
   'example',
   'examples',
   'coverage',


### PR DESCRIPTION
Some packages put css files under assets. Example: https://unpkg.com/react-github-button@0.1.11/assets/