### PR TITLE
feat: support npm_config_cache to change default cache dir (#335)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -155,6 +155,10 @@ let cacheDir = argv.cache === false ? '' : null;
 if (production) {
   cacheDir = '';
 }
+// support npm_config_cache to change default cache dir
+if (cacheDir === null && process.env.npm_config_cache) {
+  cacheDir = process.env.npm_config_cache;
+}
 
 let forbiddenLicenses = argv['forbidden-licenses'];
 forbiddenLicenses = forbiddenLicenses ? forbiddenLicenses.split(',') : null;

--- a/test/install-cache-strict.test.js
+++ b/test/install-cache-strict.test.js
@@ -49,4 +49,17 @@ describe('test/install-cache-strict.test.js', () => {
       .end();
     assert(fs.statSync(path.join(homedir, '.npminstall_tarball/d/e/b/u/debug')));
   });
+
+  it('should read disk cache from npm_config_cache env', function* () {
+    yield coffee.fork(npminstall, [], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir,
+        npm_config_cache: path.join(homedir, 'foocache/.npminstall_tarball'),
+      }),
+    })
+      .debug()
+      .end();
+    assert(fs.statSync(path.join(homedir, 'foocache/.npminstall_tarball/d/e/b/u/debug')));
+  });
 });


### PR DESCRIPTION
```bash
npm_config_cache=/oss/cache/.npminstall npminstall koa
```