### PR TITLE
chore: exports local_install/runPostInstallTasks function

### DIFF
--- a/lib/local_install.js
+++ b/lib/local_install.js
@@ -104,6 +104,8 @@ module.exports = async options => {
   }
 };
 
+exports.runPostInstallTasks = runPostInstallTasks;
+
 async function _install(options) {
   const rootPkgFile = path.join(options.root, 'package.json');
   const rootPkg = await utils.readJSON(rootPkgFile);


### PR DESCRIPTION
tnpm 走内部服务端生成依赖安装 node_modules，需要执行 postinstall，这里直接服用 npminstall 的实现。