### PR TITLE
fix: do `fixBin` in windows

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -40,6 +40,9 @@ async function bin(parentDir, pkg, pkgDir, options) {
     const srcBin = path.join(pkgDir, bins[name]);
     const destBin = path.join(binDir, name);
     await linkBin(srcBin, destBin);
+    // ensure that bin are executable and not containing
+    // windows line-endings(CRLF) on the hashbang line
+    await fixBin(srcBin, 0o755);
     if (showBinLog) {
       options.console.info('[%s] link %s@ -> %s',
         chalk.green(pkg.name + '@' + pkg.version), chalk.magenta(destBin), srcBin);
@@ -61,7 +64,4 @@ async function linkBin(src, dest) {
   }
 
   await utils.forceSymlink(src, dest);
-  // ensure that bin are executable and not containing
-  // windows line-endings(CRLF) on the hashbang line
-  await fixBin(src, 0o755);
 }


### PR DESCRIPTION
把 windows 下 chmod 操作加回去，同时会增加 windows 下 shebang 的处理

![image](https://user-images.githubusercontent.com/6828924/137699325-45c9cdfa-4768-4281-8e68-f3884b095988.png)

但是实测 windows 下设置 chmod 755 是无效的，一直都是 666，所以 windows 下测试跳过权限 mode 的断言

