### PR TITLE
fixed:#363

### DIFF
--- a/lib/local_install.js
+++ b/lib/local_install.js
@@ -27,6 +27,7 @@ const createResolution = require('./resolution');
 const formatInstallOptions = require('./format_install_options');
 const link = require('./link');
 const bin = require('./bin');
+const Context = require('./context');
 
 /**
  * npm install
@@ -51,7 +52,7 @@ const bin = require('./bin');
  *  - {Boolean} [disableDedupe] - disable dedupe mode, will back to npm@2 node_modules tree
  * @param {Object} context - install context
  */
-module.exports = async (options, context) => {
+module.exports = async (options, context = new Context()) => {
   options = formatInstallOptions(options);
   options.spinner && options.spinner.start();
   let traceTimer;


### PR DESCRIPTION
fixed:[#363 ](https://github.com/cnpm/npminstall/issues/363)
fixed the error that can't use by npminstall({options}) on version '^5.0.0'