### PR TITLE
deps: upgrade ora@5 for security

### DIFF
--- a/lib/format_install_options.js
+++ b/lib/format_install_options.js
@@ -7,7 +7,6 @@ const awaitEvent = require('await-event');
 const assert = require('assert');
 const path = require('path');
 const EventEmitter = require('events');
-// lock ora@~1.3.0, ora >= 1.4.0 will cause spinner won't show log on unittest
 const ora = require('ora');
 
 module.exports = function formatInstallOptions(options) {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "normalize-package-data": "^2.5.0",
     "npm-normalize-package-bin": "^1.0.1",
     "npm-package-arg": "^8.1.5",
-    "ora": "^3.4.0",
+    "ora": "^5.4.1",
     "p-map": "^2.1.0",
     "pacote": "^12.0.2",
     "runscript": "^1.3.0",


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908

Detailed paths
Introduced through: npminstall@5.2.2 › ora@3.4.0 › strip-ansi@5.2.0 › ansi-regex@4.1.0
Remediation: Upgrade to ora@4.0.3.