### PR TITLE
fix: npminstall multi-registry options

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -193,7 +193,8 @@ const inChina = argv.china || !!process.env.npm_china;
 // if exists, override default china mirror url
 const customChinaMirrorUrl = argv['custom-china-mirror-url'];
 
-let registry = argv.registry || process.env.npm_registry;
+// example: npminstall --registry xx --registry xxxx
+let registry = (Array.isArray(argv.registry) ? argv.registry[0] : argv.registry) || process.env.npm_registry;
 if (inChina) {
   registry = registry || globalConfig.chineseRegistry;
 }

--- a/test/custom-registry.test.js
+++ b/test/custom-registry.test.js
@@ -16,6 +16,7 @@ describe('test/custom-registry.test.js', () => {
   it('should install with custom registry', async () => {
     const args = [
       '--registry=https://r.cnpmjs.org?bucket=foo',
+      '--registry=https://r.cnpmjs.org?bucket=bar',
       '-d',
     ];
     await coffee.fork(helper.npminstall, args, { cwd: tmp })


### PR DESCRIPTION
TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received an instance of Array