### PR TITLE
🐛 FIX: Use detect-libc to get libc family

### DIFF
--- a/lib/download/npm.js
+++ b/lib/download/npm.js
@@ -15,6 +15,7 @@ const moment = require('moment');
 const os = require('os');
 const semver = require('semver');
 const utility = require('utility');
+const { family: getLibcFamily } = require('detect-libc');
 const get = require('../get');
 const utils = require('../utils');
 const config = require('../cnpm_config');
@@ -248,9 +249,8 @@ async function download(pkg, options) {
   }
   // dont download pkg in not matched libc
   if (Array.isArray(pkg.libc)) {
-    const currentLibc = utils.getLibc();
-    debug('currentLibc', currentLibc, pkg.libc);
-    if (!utils.matchPlatform(currentLibc, pkg.libc)) {
+    const currentLibc = await getLibcFamily();
+    if (currentLibc && !utils.matchPlatform(currentLibc, pkg.libc)) {
       const errMsg = `[${pkg.name}@${pkg.version}] skip download for reason ${pkg.libc.join(', ')} dont includes your libc ${currentLibc}`;
       const err = new Error(errMsg);
       err.name = 'UnSupportedPlatformError';

--- a/lib/install.js
+++ b/lib/install.js
@@ -28,7 +28,7 @@ async function install(parentDir, pkg, ancestors, options, context) {
     if (pkg.optional) {
       if (err.name === 'UnSupportedPlatformError') {
         // ignore log error
-        debug(err);
+        debug('%s', err.message);
         return;
       }
       options.console.error(chalk.yellow(`[${pkg.name}@${pkg.version}] optional install error: ${err.stack}`));

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -463,25 +463,6 @@ exports.getBugVersions = async (registry, globalOptions) => {
   return pkg.config['bug-versions'];
 };
 
-// detect libc
-// follow yarn impl: https://github.com/yarnpkg/berry/pull/3981/files#diff-f9ba955128e960171ac97ce06b0b0a940bb074af2794429a9f03c75f2a3bd459R10
-exports.getLibc = () => {
-  if (process.platform === 'win32') return null;
-  const report = process.report && process.report.getReport() || {};
-  const sharedObjects = report.sharedObjects || [];
-
-  // Matches the first group if libc, second group if musl
-  const libcRE = /\/(?:(ld-linux-|[^/]+-linux-gnu\/)|(libc.musl-|ld-musl-))/i;
-  for (const sharedObject of sharedObjects) {
-    const m = sharedObject.match(libcRE);
-    if (m) {
-      if (m[1]) return 'libc';
-      if (m[2]) return 'musl';
-    }
-  }
-  return null;
-};
-
 // match platform, arch or libc
 // see https://docs.npmjs.com/cli/v7/configuring-npm/package-json#os
 exports.matchPlatform = (current, osNames) => {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cmd-shim-hotfix": "^3.0.3",
     "debug": "^4.1.1",
     "destroy": "^1.0.4",
+    "detect-libc": "^2.0.1",
     "fs-extra": "^7.0.1",
     "minimatch": "^3.0.4",
     "minimist": "^1.2.0",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -35,6 +35,8 @@ describe('test/utils.test.js', () => {
       assert(utils.matchPlatform('glibc', []));
       assert(utils.matchPlatform('musl', []));
       assert(utils.matchPlatform(null, []));
+      assert(utils.matchPlatform(null, [ 'musl' ]));
+      assert(utils.matchPlatform(null, [ 'glibc' ]));
       assert(utils.matchPlatform('glibc', [ 'glibc' ]));
       assert(utils.matchPlatform('glibc', [ 'glibc', 'musl' ]));
       assert(utils.matchPlatform('musl', [ 'glibc', 'musl' ]));
@@ -69,8 +71,6 @@ describe('test/utils.test.js', () => {
     });
 
     it('should not match libc names', () => {
-      assert(!utils.matchPlatform(null, [ 'musl' ]));
-      assert(!utils.matchPlatform(null, [ 'glibc' ]));
       assert(!utils.matchPlatform('glibc', [ 'musl' ]));
       assert(!utils.matchPlatform('musl', [ 'glibc' ]));
       assert(!utils.matchPlatform('glibc', [ '!glibc' ]));


### PR DESCRIPTION
Ignore libc check if libc family is null