### PR TITLE
Revert "feat: upgrade node-gyp@8 to support python3 (#385)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ms": "^2.1.1",
     "mz": "^2.7.0",
     "mz-modules": "^2.1.0",
-    "node-gyp": "^8.4.1",
+    "node-gyp": "^4.0.0",
     "node-homedir": "^1.1.1",
     "normalize-package-data": "^2.5.0",
     "npm-normalize-package-bin": "^1.0.1",


### PR DESCRIPTION
This reverts commit d02fa246dc096d8237ea63693ede9c88e607e2b1.

https://github.com/cnpm/npminstall/pull/385#issuecomment-1077352642

Keep should Python2, we will release major version to support Python3