### PR TITLE
fix: fix request nydusd api error when using urllib >= 3.x

### DIFF
--- a/packages/npminstall/package.json
+++ b/packages/npminstall/package.json
@@ -53,7 +53,7 @@
     "runscript": "^1.3.0",
     "semver": "^6.0.0",
     "tar": "^4.4.8",
-    "urllib": "^3.0.3",
+    "urllib": "^2.39.1",
     "utility": "^1.16.1"
   },
   "devDependencies": {


### PR DESCRIPTION
found `curl -v -GET --unix-socket /Users/beacelee/.npminstall/rapid-mode/nydusd.sock http://unix/api/v1/daemon` is worked, urllib request error when urllib's version >= 3.x.

This error will cause the nydus status detection to fail all the time

![image](https://user-images.githubusercontent.com/13284978/195378777-e9cebe60-0f34-4916-9ee6-627f7831dc73.png)


