### PR TITLE
feat: add support for process.env.npminstall_cache

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -196,6 +196,9 @@ if (production) {
 if (cacheDir === null && process.env.npm_config_cache) {
   cacheDir = process.env.npm_config_cache;
 }
+if (process.env.npminstall_cache) {
+  cacheDir = process.env.npminstall_cache;
+}
 
 let forbiddenLicenses = argv['forbidden-licenses'];
 forbiddenLicenses = forbiddenLicenses ? forbiddenLicenses.split(',') : null;

--- a/test/install-cache-strict.test.js
+++ b/test/install-cache-strict.test.js
@@ -59,4 +59,17 @@ describe('test/install-cache-strict.test.js', () => {
       .end();
     assert(await fs.stat(path.join(homedir, '.npminstall_tarball/d/e/b/u/debug')));
   });
+
+  it('should read disk cache from npminstall_cache env', async () => {
+    await coffee.fork(helper.npminstall, [], {
+      cwd: demo,
+      env: Object.assign({}, process.env, {
+        HOME: homedir,
+        npminstall_cache: path.join(homedir, 'foocache/.npminstall_tarball'),
+      }),
+    })
+      .debug()
+      .end();
+    assert(await fs.stat(path.join(homedir, 'foocache/.npminstall_tarball/d/e/b/u/debug')));
+  });
 });


### PR DESCRIPTION
### 现状

npminstall 内置了 tarball 的缓存能力，默认的缓存地址为 `~/.npminstall_tarball`.   npminstall 不支持通过 `--cache` 配置缓存目录的位置，但支持通过 `process.env.npm_config_cache` 进行配置。

### 我们的预期

预期能通过配置文件或环境变量修改 npminstall 缓存的位置，且缓存的目录能与 npm 区分开

### 遇到的问题

如果使用 `npm_config_cache` 配置 npminstall 的缓存位置，会同时修改 npm 的缓存位置，导致两个缓存总是位于同一个父目录

### 修改方法
新增 `process.env.npminstall_cache` 配置，允许配置缓存位置，且能够和 npm 的缓存目录分隔开。  (或者其他方式，能满足需求即可）
